### PR TITLE
fix: Preload tenant flows and templates in `GetTenant` similar to `GetOrCreateTenant`

### DIFF
--- a/kontrol-service/database/tenant.go
+++ b/kontrol-service/database/tenant.go
@@ -46,7 +46,7 @@ func (db *Db) GetTenant(
 	tenantId string,
 ) (*Tenant, error) {
 	var tenant Tenant
-	result := db.db.Where("tenant_id = ?", tenantId).First(&tenant)
+	result := db.db.Where("tenant_id = ?", tenantId).Preload("Flows").Preload("Templates").First(&tenant)
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			return nil, nil


### PR DESCRIPTION
Some API calls did not see the tenant flows.