### PR TITLE
feat: Add more details about API compatibility

### DIFF
--- a/kontrol-service/main.go
+++ b/kontrol-service/main.go
@@ -106,7 +106,7 @@ func startServer(isDevMode bool) {
 					msg := "The server could not handle this request.  Please make sure you are using the latest Kardinal API.  For the CLI, it means using the latest CLI release.  You can open an issue against the Kardinal repo if you continue to get this error at https://github.com/kurtosis-tech/kardinal/issues/new"
 					internalServerErrorResponse := cli_api.ErrorJSONResponse{
 						Error: "Internal Server Error",
-						Msg: &msg,
+						Msg:   &msg,
 					}
 
 					// Handle the panic and return a 500 error response

--- a/kontrol-service/main.go
+++ b/kontrol-service/main.go
@@ -103,8 +103,10 @@ func startServer(isDevMode bool) {
 			defer func() {
 				if r := recover(); r != nil {
 
+					msg := "The server could not handle this request.  Please make sure you are using the latest Kardinal API.  For the CLI, it means using the latest CLI release.  You can open an issue against the Kardinal repo if you continue to get this error at https://github.com/kurtosis-tech/kardinal/issues/new"
 					internalServerErrorResponse := cli_api.ErrorJSONResponse{
-						Error: "internal server error",
+						Error: "Internal Server Error",
+						Msg: &msg,
 					}
 
 					// Handle the panic and return a 500 error response
@@ -118,7 +120,7 @@ func startServer(isDevMode bool) {
 					default:
 						debugMsg = "recover didn't get error msg"
 					}
-					logrus.Errorf("HTTP server handle this internal panic: %s", debugMsg)
+					logrus.Errorf("HTTP server handled this internal panic: %s", debugMsg)
 				}
 			}()
 			return next(c)


### PR DESCRIPTION
Issuing requests with the wrong body currently returns a vague 500 error message.  This change tries to clarify things a bit.  Better would be to validate the body in each handling function and return a 400.  This can be done in a separate PR if needed.

Related: https://github.com/kurtosis-tech/kardinal/pull/235