### PR TITLE
feat: improve user profile placeholder in nav

### DIFF
--- a/kontrol-frontend/src/components/Navbar.tsx
+++ b/kontrol-frontend/src/components/Navbar.tsx
@@ -7,9 +7,21 @@ import {
   Image,
   Spacer,
   AvatarBadge,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  Button,
 } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
 
 const Navbar = () => {
+  const navigate = useNavigate();
+
+  const navigateToPlaceholder = () => {
+    navigate("profile");
+  };
+
   return (
     <Box
       bg="white"
@@ -21,7 +33,6 @@ const Navbar = () => {
       borderBottomColor="gray.100"
     >
       <Flex h={16} alignItems="center">
-        {/* Logo */}
         <Link href="/" display="flex" alignItems="center">
           <Image
             src="/logo.png"
@@ -36,17 +47,19 @@ const Navbar = () => {
 
         <Spacer />
 
-        {/* User Profile */}
         <Flex alignItems="center">
-          <Avatar size="sm" name="Charlie Brown">
-            <AvatarBadge boxSize="1.25em" bg="green.500" />
-          </Avatar>
-          <Box ml={2}>
-            <Text>Charlie Brown</Text>
-            <Text fontSize="sm" color="gray.500">
-              ACME Corporation
-            </Text>
-          </Box>
+          <Menu>
+            <MenuButton as={Button} p={0} bg={"white"}>
+              <Avatar size="sm">
+                <AvatarBadge boxSize="1.25em" bg="green.500" />
+              </Avatar>
+            </MenuButton>
+            <MenuList>
+              <MenuItem onClick={navigateToPlaceholder}>Profile</MenuItem>
+              <MenuItem onClick={navigateToPlaceholder}>Settings</MenuItem>
+              <MenuItem onClick={navigateToPlaceholder}>Log in</MenuItem>
+            </MenuList>
+          </Menu>
         </Flex>
       </Flex>
     </Box>

--- a/kontrol-frontend/src/main.tsx
+++ b/kontrol-frontend/src/main.tsx
@@ -11,6 +11,7 @@ import FlowsCreate from "@/pages/FlowsCreate";
 import FlowsIndex from "@/pages/FlowsIndex";
 import MaturityGates from "@/pages/MaturityGates";
 import TrafficConfiguration from "@/pages/TrafficConfiguration";
+import Profile from "@/pages/Profile";
 import NotFound from "@/pages/NotFound";
 
 import { ErrorBoundary } from "react-error-boundary";
@@ -59,6 +60,10 @@ const router = createBrowserRouter([
       {
         path: "data-configuration",
         element: <DataConfiguration />,
+      },
+      {
+        path: "profile",
+        element: <Profile />,
       },
     ],
   },

--- a/kontrol-frontend/src/pages/Profile.tsx
+++ b/kontrol-frontend/src/pages/Profile.tsx
@@ -1,0 +1,19 @@
+import EmptyState from "@/components/EmptyState";
+import { BiChevronLeft } from "react-icons/bi";
+import { FiUser } from "react-icons/fi";
+
+const Page = () => {
+  return (
+    <EmptyState
+      icon={FiUser}
+      buttonText="Go back"
+      buttonIcon={BiChevronLeft}
+      buttonTo="../traffic-configuration"
+    >
+      We’re working on getting this functionality up and running. We’ll let you
+      know when it’s ready for you!
+    </EmptyState>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
Improve the user profile placeholder by removing the "Charlie Brown" name and replacing with a menu. The menu has some placeholder items on them that simply redirect to a coming soon page.

------- 

<img width="1260" alt="Screenshot 2024-09-26 at 1 55 56 PM" src="https://github.com/user-attachments/assets/0cf812cc-82c6-480d-b572-6d005ffab4dc">

-------

<img width="1249" alt="Screenshot 2024-09-26 at 1 57 11 PM" src="https://github.com/user-attachments/assets/db9c0f45-1d7e-4bb7-b4a4-b6d379095432">

-------

<img width="1254" alt="Screenshot 2024-09-26 at 1 57 19 PM" src="https://github.com/user-attachments/assets/fdc2e4f4-3e42-4f5b-aaf3-8e44f0d8500a">
